### PR TITLE
updated metadata argument building

### DIFF
--- a/opentsg-core/_docs/core/doc.md
+++ b/opentsg-core/_docs/core/doc.md
@@ -46,4 +46,13 @@ Then if no file is found then an error is returned.
 For step 3 the factories are searched depth first, so only folder locations
 that are parents of the factory are included. No width based searches occur.
 
+### Metadata Arguments update order
+
+When passing metadata through the input files, the child metadata overwrites
+the parent metadata, if applicable. As part of this the metadata is mustached
+as you go along. So a parent will declare `"title": "TestTitle"` then the child
+will use `"title": "{{title}}-update"`, resulting in a final argument value of
+`"title": "TestTitle-update"` reaching the widget. This means arguments can
+be built up throughout the initialisation process.
+
 ## TPIG

--- a/opentsg-core/config/core/testdata/frame_generate2/metadataUpdates/canvas.json
+++ b/opentsg-core/config/core/testdata/frame_generate2/metadataUpdates/canvas.json
@@ -1,0 +1,9 @@
+{
+    "type": "builtin.canvasoptions",
+    "name": ["{{title}}-{{framenumber}}.png"],
+    "frameSize": { "w": 4096, "h": 2160 },
+    "linewidth": 0.5,
+    "filedepth": 16,
+    "gridColumns": 1024,
+    "gridRows": 540
+  }

--- a/opentsg-core/config/core/testdata/frame_generate2/metadataUpdates/frame.json
+++ b/opentsg-core/config/core/testdata/frame_generate2/metadataUpdates/frame.json
@@ -1,0 +1,10 @@
+{
+    "include": [
+        {"uri":"canvas.json", "name":"canvas",  "args":["title","update"]}
+    ],
+    "create":[
+        { 
+            "canvas":{"title":"{{update}}-{{title}}", "update":"frame"}
+        }
+    ]
+}

--- a/opentsg-core/config/core/testdata/frame_generate2/metadataUpdates/resRoot.yaml
+++ b/opentsg-core/config/core/testdata/frame_generate2/metadataUpdates/resRoot.yaml
@@ -1,0 +1,11 @@
+frame.canvas:
+    filedepth: 16
+    frameSize:
+        h: 2160
+        w: 4096
+    gridColumns: 1024
+    gridRows: 540
+    linewidth: 0.5
+    name:
+        - sequence-TestTitle-{{framenumber}}.png
+    type: builtin.canvasoptions

--- a/opentsg-core/config/core/testdata/frame_generate2/metadataUpdates/sequence.json
+++ b/opentsg-core/config/core/testdata/frame_generate2/metadataUpdates/sequence.json
@@ -1,0 +1,20 @@
+{
+    "include": [
+        {
+            "uri": "frame.json",
+            "name": "frame",
+            "args": [
+                "title",
+                "update"
+            ]
+        }
+    ],
+    "create": [
+        {
+            "frame": {
+                "update": "sequence",
+                "title": "TestTitle"
+            }
+        }
+    ]
+}

--- a/opentsg-core/config/core/testdata/frame_generate2/metadataUpdates/sequenceErr.json
+++ b/opentsg-core/config/core/testdata/frame_generate2/metadataUpdates/sequenceErr.json
@@ -1,0 +1,26 @@
+{
+    "include": [
+        {
+            "uri": "frame.json",
+            "name": "frame",
+            "args": [
+                "title",
+                "update"
+            ]
+        }
+    ],
+    "create": [
+        {
+            "frame": {
+                "update": "sequence",
+                "title": "TestTitle-{{title}}"
+            }
+        }, 
+        {
+            "frame": {
+                "updater": "sequence",
+                "title": "TestTitle"
+            }
+        }
+    ]
+}

--- a/opentsg-core/config/core/testdata/frame_generate2/swatch.json
+++ b/opentsg-core/config/core/testdata/frame_generate2/swatch.json
@@ -1,11 +1,4 @@
 {
-    "documentation": [
-      "## MSG Swatch widget",
-      "",
-      "Render a matrix of pyramid squares over a background (possibly",
-      "",
-      "`swatchParams` property is set by parent"
-    ],
     "include": [
       { "uri": "pyramid.json", "name": "pyramid" },
       { "uri": "pyramid-data-new.json", "name": "d" }


### PR DESCRIPTION
# Metadata Arguments update order

When passing metadata through the input files, the child metadata overwrites
the parent metadata, if applicable. As part of this the metadata is mustached
as you go along. So a parent will declare `"title": "TestTitle"` then the child
will use `"title": "{{title}}-update"`, resulting in a final argument value of
`"title": "TestTitle-update"` reaching the widget. This means arguments can
be built up throughout the initialisation process.